### PR TITLE
Fixing installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ http://openseadragon.github.io/
 Add the gem to your Gemfile:
 
 ```ruby
-gem 'openseadragon-rails'
+gem 'openseadragon'
 ```
 
 Run bundle install: 


### PR DESCRIPTION
Your gem is called `openseadragon`, not `openseadragon-rails`.