### PR TITLE
Add support for jQuery 3

### DIFF
--- a/app/assets/javascripts/openseadragon/rails.js
+++ b/app/assets/javascripts/openseadragon/rails.js
@@ -5,7 +5,8 @@
     $('picture[data-openseadragon]').openseadragon();
   }
 
-  var handler = 'ready';
+  const jquery3 = parseInt($.fn.jquery.split('.')[0]) >= 3;
+  let handler = 'ready';
   if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
     // Turbolinks 5
     if (Turbolinks.BrowserAdapter) {
@@ -15,5 +16,14 @@
       handler = 'page:load ready';
     }
   }
-  $(document).on(handler, initOpenSeadragon);
+
+  // Support for $(document).on( "ready", handler ) was removed in jQuery 3
+  if (jquery3 && handler.includes('ready')) {
+    handler = handler.replace('ready', '').trim();
+    $(initOpenSeadragon);
+  }
+
+  if (handler) {
+    $(document).on(handler, initOpenSeadragon);
+  }
 })(jQuery);


### PR DESCRIPTION
$(document).on("ready", handler) was deprecated in jQuery 1.8 and removed in 3.

https://api.jquery.com/ready/
